### PR TITLE
AdaptivePoW integration

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -95,7 +95,7 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nAdaptativePoWActivationThreshold = 4796610;
-        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
+        consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -95,7 +95,7 @@ public:
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nAdaptativePoWActivationThreshold = 4835785;
         consensus.nMinerConfirmationWindow = 2016; // 2016 before apow HF ; nPowTargetTimespan / nPowTargetSpacing
-        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
+//        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4841410;
+        consensus.nAdaptativePoWActivationThreshold = 5841410;
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,8 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nAdaptativePoWActivationThreshold = 4835785;
-        consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
+        consensus.nMinerConfirmationWindow = 2016; // 2016 before apow HF ; nPowTargetTimespan / nPowTargetSpacing
+        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 5841410; // 6663534 + 34560 (approx 24th July 2020, 11 PM UTC)
+        consensus.nAdaptativePoWActivationThreshold = 6795000; // (approx 5th Aug 2020, 8:30 PM UTC)
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -82,13 +82,12 @@ public:
         consensus.BIP66Height = 0;//363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("0000007fffff0000000000000000000000000000000000000000000000000000");
         consensus.nPowTargetSpacing = 10;// * 60;
-	consensus.nLwmaAjustedWeight = 1350;
+        consensus.nLwmaAjustedWeight = 1350;
 
         consensus.nPowAveragingWindow = 17;
 //      assert(maxUint/UintToArith256(consensus.powLimit) >= consensus.nPowAveragingWindow);
         consensus.nPowMaxAdjustDown = 32; // 32% adjustment down
         consensus.nPowMaxAdjustUp = 16; // 16% adjustment up
-        //consensus.nPowTargetSpacing = 1 * 60;
         
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4835515;
+        consensus.nAdaptativePoWActivationThreshold = 5835515;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 6795000; // (approx 5th Aug 2020, 8:30 PM UTC)
+        consensus.nAdaptivePoWActivationThreshold = 6795000; // (approx 5th Aug 2020, 8:30 PM UTC)
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptivePoWActivationThreshold = 6795000; // (approx 5th Aug 2020, 8:30 PM UTC)
+        consensus.nAdaptivePoWActivationThreshold = 6816520; // (approx 19th Aug 2020, 9:00 PM UTC)
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4796610;
+        consensus.nAdaptativePoWActivationThreshold = 4797020;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4819600;
+        consensus.nAdaptativePoWActivationThreshold = 4834255;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 5835515;
+        consensus.nAdaptativePoWActivationThreshold = 4835785;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4797020;
+        consensus.nAdaptativePoWActivationThreshold = 4819600;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4795780;
+        consensus.nAdaptativePoWActivationThreshold = 4796610;
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4835785;
+        consensus.nAdaptativePoWActivationThreshold = 4840400;
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nAdaptativePoWActivationThreshold = 4835785;
-        consensus.nMinerConfirmationWindow = 2016; // 2016 before apow HF ; nPowTargetTimespan / nPowTargetSpacing
+        consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4840610;
+        consensus.nAdaptativePoWActivationThreshold = 4841410;
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -94,7 +94,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4834255;
+        consensus.nAdaptativePoWActivationThreshold = 4835515;
         consensus.nMinerConfirmationWindow = 17; // 2016 before changed ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptativePoWActivationThreshold = 4840400;
+        consensus.nAdaptativePoWActivationThreshold = 4840610;
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -93,7 +93,7 @@ public:
         consensus.nPowTargetTimespan = 17 * consensus.nPowTargetSpacing;
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
-        consensus.nAdaptivePoWActivationThreshold = 6816520; // (approx 19th Aug 2020, 9:00 PM UTC)
+        consensus.nAdaptivePoWActivationThreshold = 6874120; // (approx 23th Aug 2020, 9:00 PM UTC)
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
 //        consensus.nMinerConfirmationWindowApow = 17; // 17 after apow HF ; nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -66,7 +66,6 @@ struct Params {
      */
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
-    uint32_t nMinerConfirmationWindowApow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -66,6 +66,7 @@ struct Params {
      */
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
+    uint32_t nMinerConfirmationWindowApow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -58,7 +58,7 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
-    int nAdaptativePoWActivationThreshold;
+    int nAdaptivePoWActivationThreshold;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -42,7 +42,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime;
-    if (pindexPrev->nHeight + 1 <= consensusParams.nAdaptativePoWActivationThreshold)
+    if (pindexPrev->nHeight + 1 <= consensusParams.nAdaptivePoWActivationThreshold)
     {
         nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
         if (nOldTime < nNewTime)
@@ -55,7 +55,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     }
 
     // Updating time can change work required on testnet and apow:
-    if (consensusParams.fPowAllowMinDifficultyBlocks || pindexPrev->nHeight + 1 > consensusParams.nAdaptativePoWActivationThreshold)
+    if (consensusParams.fPowAllowMinDifficultyBlocks || pindexPrev->nHeight + 1 > consensusParams.nAdaptivePoWActivationThreshold)
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
     
     return nNewTime - nOldTime;
@@ -135,7 +135,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
     uint32_t proposedTime = GetAdjustedTime();
-    if (pindexPrev->nHeight + 1 > Params().GetConsensus().nAdaptativePoWActivationThreshold)
+    if (pindexPrev->nHeight + 1 > Params().GetConsensus().nAdaptivePoWActivationThreshold)
     {
         if (proposedTime == nMedianTimePast)
         {
@@ -180,7 +180,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout.resize(1);
     coinbaseTx.vout[0].scriptPubKey = scriptPubKeyIn;
     coinbaseTx.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
-    if ( pindexPrev->nHeight + 1 <= chainparams.GetConsensus().nAdaptativePoWActivationThreshold )
+    if ( pindexPrev->nHeight + 1 <= chainparams.GetConsensus().nAdaptivePoWActivationThreshold )
         coinbaseTx.nLockTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
     else coinbaseTx.nLockTime = std::max((int64_t)(pindexPrev->nTime+1), GetAdjustedTime());
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -40,7 +40,6 @@ uint64_t nLastBlockWeight = 0;
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
-//    LogPrintf("UpdateTime pindexPrev->nHeight %d\n", pindexPrev->nHeight);
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime;
     if (pindexPrev->nHeight + 1 <= consensusParams.nAdaptativePoWActivationThreshold)
@@ -48,16 +47,11 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     else
         nNewTime = std::max((int64_t)(pindexPrev->nTime+1), GetAdjustedTime());
 
-//    if (nOldTime < nNewTime && pindexLast->nHeight + 1 <= consensusParams.nAdaptativePoWActivationThreshold)
         pblock->nTime = nNewTime;        
 
-    // LogPrintf("UpdateTime before call to GetNextWorkRequired\n");
-                        
     // Updating time can change work required on testnet and apow (?):
-    if (consensusParams.fPowAllowMinDifficultyBlocks || pindexPrev->nHeight + 1 > consensusParams.nAdaptativePoWActivationThreshold)    {
+    if (consensusParams.fPowAllowMinDifficultyBlocks || pindexPrev->nHeight + 1 > consensusParams.nAdaptativePoWActivationThreshold)
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
-        //LogPrintf(">>>>>>> miner pblock->nBits %x\n",pblock->nBits);
-    }
     
     return nNewTime - nOldTime;
 }
@@ -189,21 +183,13 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-    LogPrintf("CreateNewBlock(): GetBlockHash ok\n");
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-    LogPrintf("CreateNewBlock(): UpdateTime ok\n");
     pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
-    LogPrintf(">>>>>>>> miner: pblock->nBits %x\n",pblock->nBits);
-        pblock->nNonce         = 0;
+    pblock->nNonce         = 0;
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(*pblock->vtx[0]);
-    LogPrintf("CreateNewBlock(): GetLegacySigOpCount ok\n");
-    
     CValidationState state;
-    if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {
-        LogPrintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state));
+    if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false))
         throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
-    }
-    LogPrintf("CreateNewBlock(): TestBlockValidity ok\n");
     int64_t nTime2 = GetTimeMicros();
 
     LogPrintf("CreateNewBlock() packages: %.2fms (%d packages, %d updated descendants), validity: %.2fms (total %.2fms)\n", 0.001 * (nTime1 - nTimeStart), nPackagesSelected, nDescendantsUpdated, 0.001 * (nTime2 - nTime1), 0.001 * (nTime2 - nTimeStart));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -40,7 +40,7 @@ uint64_t nLastBlockWeight = 0;
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
 {
-    LogPrintf("UpdateTime pindexPrev->nHeight %d\n", pindexPrev->nHeight);
+//    LogPrintf("UpdateTime pindexPrev->nHeight %d\n", pindexPrev->nHeight);
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime;
     if (pindexPrev->nHeight + 1 <= consensusParams.nAdaptativePoWActivationThreshold)
@@ -56,7 +56,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     // Updating time can change work required on testnet and apow (?):
     if (consensusParams.fPowAllowMinDifficultyBlocks || pindexPrev->nHeight + 1 > consensusParams.nAdaptativePoWActivationThreshold)    {
         pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, consensusParams);
-        LogPrintf(">>>>>>> miner pblock->nBits %x\n",pblock->nBits);
+        //LogPrintf(">>>>>>> miner pblock->nBits %x\n",pblock->nBits);
     }
     
     return nNewTime - nOldTime;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -192,7 +192,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
     int64_t nTime2 = GetTimeMicros();
 
-    LogPrintf("CreateNewBlock() packages: %.2fms (%d packages, %d updated descendants), validity: %.2fms (total %.2fms)\n", 0.001 * (nTime1 - nTimeStart), nPackagesSelected, nDescendantsUpdated, 0.001 * (nTime2 - nTime1), 0.001 * (nTime2 - nTimeStart));
+    LogPrint(BCLog::BENCH, "CreateNewBlock() packages: %.2fms (%d packages, %d updated descendants), validity: %.2fms (total %.2fms)\n", 0.001 * (nTime1 - nTimeStart), nPackagesSelected, nDescendantsUpdated, 0.001 * (nTime2 - nTime1), 0.001 * (nTime2 - nTimeStart));
 
     return std::move(pblocktemplate);
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1643,7 +1643,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             vRecv >> nStartingHeight;
         }
         LogPrintf("nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
-        if (nStartingHeight > chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
+        if (chainActive.Height() > chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
             nVersion < MIN_PEER_PROTO_VERSION_AFTER_APOW)
         {
             // disconnect from peers older than this proto version

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1642,8 +1642,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (!vRecv.empty()) {
             vRecv >> nStartingHeight;
         }
-        LogPrintf("nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, chainActive.Height(), chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
-        if (chainActive.Height() + 1 >= chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
+        LogPrintf("nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
+        if (nStartingHeight > chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
             nVersion < MIN_PEER_PROTO_VERSION_AFTER_APOW)
         {
             // disconnect from peers older than this proto version

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1642,12 +1642,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (!vRecv.empty()) {
             vRecv >> nStartingHeight;
         }
-        LogPrintf("nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
+        // LogPrintf("[apow] nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
         if (chainActive.Height() > chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
             nVersion < MIN_PEER_PROTO_VERSION_AFTER_APOW)
         {
             // disconnect from peers older than this proto version
-            LogPrintf("[apow fork] peer=%d using obsolete (apow fork) version %i; disconnecting\n", pfrom->GetId(), nVersion);
+            LogPrint(BCLog::NET, "[apow hard fork] peer=%d using obsolete version %i; disconnecting\n", pfrom->GetId(), nVersion);
             connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_OBSOLETE,
                                strprintf("Version must be %d or greater", MIN_PEER_PROTO_VERSION_AFTER_APOW)));
             pfrom->fDisconnect = true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1642,8 +1642,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (!vRecv.empty()) {
             vRecv >> nStartingHeight;
         }
-        // LogPrintf("[apow] nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptativePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptativePoWActivationThreshold);
-        if (chainActive.Height() > chainparams.GetConsensus().nAdaptativePoWActivationThreshold && 
+        // LogPrintf("[apow] nVersion %d | MIN_PEER_PROTO_VERSION_AFTER_APOW %d | nHeight %d | chainparams.GetConsensus().nAdaptivePoWActivationThreshold = %d\n", nVersion, MIN_PEER_PROTO_VERSION_AFTER_APOW, nStartingHeight, chainparams.GetConsensus().nAdaptivePoWActivationThreshold);
+        if (chainActive.Height() > chainparams.GetConsensus().nAdaptivePoWActivationThreshold && 
             nVersion < MIN_PEER_PROTO_VERSION_AFTER_APOW)
         {
             // disconnect from peers older than this proto version

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -311,7 +311,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
  
  }
  else {
-  LogPrintf("New Diff algo\n");
+  // LogPrintf("New Diff algo\n");
 //    if (ASSETCHAINS_ALGO != ASSETCHAINS_EQUIHASH && ASSETCHAINS_STAKED == 0)
      return lwmaGetNextWorkRequired(pindexLast, pblock, params);
  }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -517,9 +517,9 @@ unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
     // Limit adjustment step
     // Use medians to prevent time-warp attacks
     int64_t nActualTimespan = nLastBlockTime - nFirstBlockTime;
-    LogPrintf("NEW pow   nActualTimespan = %d  before dampening\n", nActualTimespan);
+    // LogPrintf("NEW pow   nActualTimespan = %d  before dampening\n", nActualTimespan);
     nActualTimespan = params.AveragingWindowTimespan() + (nActualTimespan - params.AveragingWindowTimespan())/4;
-    LogPrintf("pow   nActualTimespan = %d  before bounds\n", nActualTimespan);
+    // LogPrintf("pow   nActualTimespan = %d  before bounds\n", nActualTimespan);
 
     if ( 1 <= 0 )
     {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -313,15 +313,15 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
  else {
   // LogPrintf("New Diff algo\n");
 //    if (ASSETCHAINS_ALGO != ASSETCHAINS_EQUIHASH && ASSETCHAINS_STAKED == 0)
-     return lwmaGetNextWorkRequired(pindexLast, pblock, params);
- }
+//     return lwmaGetNextWorkRequired(pindexLast, pblock, params);
+
  
-/*
+
     arith_uint256 bnLimit;
-    if (ASSETCHAINS_ALGO == ASSETCHAINS_EQUIHASH)
+    //if (ASSETCHAINS_ALGO == ASSETCHAINS_EQUIHASH)
         bnLimit = UintToArith256(params.powLimit);
-    else
-        bnLimit = UintToArith256(params.powAlternate);
+    //else
+    //    bnLimit = UintToArith256(params.powAlternate);
     unsigned int nProofOfWorkLimit = bnLimit.GetCompact();
     // Genesis block
     if (pindexLast == NULL )
@@ -351,10 +351,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     memset(zflags,0,sizeof(zflags));
     if ( pindexLast != 0 )
         height = (int32_t)pindexLast->GetHeight() + 1;
-    if ( ASSETCHAINS_ADAPTIVEPOW > 0 && pindexFirst != 0 && pblock != 0 && height >= (int32_t)(sizeof(ct)/sizeof(*ct)) )
+    if ( /*ASSETCHAINS_ADAPTIVEPOW > 0 &&*/ pindexFirst != 0 && pblock != 0 && height >= (int32_t)(sizeof(ct)/sizeof(*ct)) )
     {
         tipdiff = (pblock->nTime - pindexFirst->nTime);
-        mult = tipdiff - 7 * ASSETCHAINS_BLOCKTIME;
+        mult = tipdiff - 7 * params.nPowTargetSpacing; // ASSETCHAINS_BLOCKTIME
         bnPrev.SetCompact(pindexFirst->nBits);
         for (i=0; pindexFirst != 0 && i<(int32_t)(sizeof(ct)/sizeof(*ct)); i++)
         {
@@ -368,7 +368,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
             if ( zflags[i] == 1 || zflags[i] == 2 ) // I, O and if TSA made it harder
                 ct[i] = zawy_ctB(ct[i],ts[i] - ts[i+1]);
         }
-        if ( ASSETCHAINS_ADAPTIVEPOW == 2 ) // TSA
+        if ( 0 ) // ASSETCHAINS_ADAPTIVEPOW == 2 ) // TSA
         {
             bnTarget = zawy_TSA_EMA(height,tipdiff,ct[0],ts[0] - ts[1]);
             nbits = bnTarget.GetCompact();
@@ -380,14 +380,14 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     for (i = 0; pindexFirst && i < params.nPowAveragingWindow; i++)
     {
         bnTmp.SetCompact(pindexFirst->nBits);
-        if ( ASSETCHAINS_ADAPTIVEPOW > 0 && pblock != 0 )
+        if ( /*ASSETCHAINS_ADAPTIVEPOW > 0*/ && pblock != 0 )
         {
             blocktime = pindexFirst->nTime;
             diff = (pblock->nTime - blocktime);
             //fprintf(stderr,"%d ",diff);
             if ( i < 6 )
             {
-                diff -= (8+i)*ASSETCHAINS_BLOCKTIME;
+                diff -= (8+i)*params.nPowTargetSpacing; // ASSETCHAINS_BLOCKTIME
                 if ( diff > mult )
                 {
                     //fprintf(stderr,"i.%d diff.%d (%u - %u - %dx)\n",i,(int32_t)diff,pblock->nTime,pindexFirst->nTime,(8+i));
@@ -407,12 +407,12 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
     bool fNegative,fOverflow; int32_t past,zawyflag = 0; arith_uint256 easy,origtarget,bnAvg {bnTot / params.nPowAveragingWindow};
     nbits = CalculateNextWorkRequired(bnAvg, pindexLast->GetMedianTimePast(), pindexFirst->GetMedianTimePast(), params);
-    if ( ASSETCHAINS_ADAPTIVEPOW > 0 )
+    if ( /*ASSETCHAINS_ADAPTIVEPOW > 0*/ )
     {
         bnTarget = arith_uint256().SetCompact(nbits);
         if ( height > (int32_t)(sizeof(ct)/sizeof(*ct)) && pblock != 0 && tipdiff > 0 )
         {
-            easy.SetCompact(KOMODO_MINDIFF_NBITS & (~3),&fNegative,&fOverflow);
+            easy.SetCompact(0x1e007fff & (~3),&fNegative,&fOverflow); // KOMODO_MINDIFF_NBITS
             if ( pblock != 0 )
             {
                 origtarget = bnTarget;
@@ -463,7 +463,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
                 {
                     bnTarget = easy;
                     fprintf(stderr,"cmp.%d mult.%d ht.%d -> easy target\n",mult>1,(int32_t)mult,height);
-                    return(KOMODO_MINDIFF_NBITS & (~3));
+                    return(0x1e007fff & (~3)); // KOMODO_MINDIFF_NBITS
                 }
                 {
                     int32_t z;
@@ -483,7 +483,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         nbits = (nbits & 0xfffffffc) | zawyflag;
     }
     return(nbits);
-    */
+  }
 }
 
 unsigned int lwmaGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -273,7 +273,7 @@ arith_uint256 zawy_TSA_EMA(int32_t height,int32_t tipdiff,arith_uint256 prevTarg
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
     if (pindexLast->nHeight + 1 <= params.nAdaptativePoWActivationThreshold) {
-     
+        // Original Chips/Bitcoin DDA     
         assert(pindexLast != nullptr);
         unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
@@ -309,7 +309,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
  
  }
  else {
-  
+    // apow DDA (first implementation by jl777 and zawy12)
     arith_uint256 bnLimit;
     bnLimit = UintToArith256(params.powLimit);
 
@@ -546,10 +546,10 @@ unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
         bnNew = bnPowLimit;
 
     /// debug print
-    LogPrintf("pow GetNextWorkRequired RETARGET\n");
-    LogPrintf("pow params.AveragingWindowTimespan() = %d    nActualTimespan = %d\n", params.AveragingWindowTimespan(), nActualTimespan);
-    LogPrintf("pow Current average: %08x  %s\n", bnAvg.GetCompact(), bnAvg.ToString());
-    LogPrintf("pow After:  %08x  %s\n", bnNew.GetCompact(), bnNew.ToString());
+    // LogPrintf("pow GetNextWorkRequired RETARGET\n");
+    // LogPrintf("pow params.AveragingWindowTimespan() = %d    nActualTimespan = %d\n", params.AveragingWindowTimespan(), nActualTimespan);
+    // LogPrintf("pow Current average: %08x  %s\n", bnAvg.GetCompact(), bnAvg.ToString());
+    // LogPrintf("pow After:  %08x  %s\n", bnNew.GetCompact(), bnNew.ToString());
 
     return bnNew.GetCompact();
 }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -394,8 +394,8 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
                     mult = diff;
                 }
             }
-            //if ( zflags[i] != 0 && zflags[0] != 0 )
-            //    bnTmp = (ct[i] / arith_uint256(3));
+            if ( zflags[i] != 0 && zflags[0] != 0 )
+                bnTmp = (ct[i] / arith_uint256(3));
         }
         bnTot += bnTmp;
         pindexFirst = pindexFirst->pprev;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -274,7 +274,7 @@ arith_uint256 zawy_TSA_EMA(int32_t height,int32_t tipdiff,arith_uint256 prevTarg
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
-    if (pindexLast->nHeight + 1 <= params.nAdaptativePoWActivationThreshold) {
+    if (pindexLast->nHeight + 1 <= params.nAdaptivePoWActivationThreshold) {
         // Original Chips/Bitcoin DDA     
         assert(pindexLast != nullptr);
         unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -3,13 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-// AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at https://github.com/jl777/komodo
 /******************************************************************************
  * Copyright © 2014-2020 The SuperNET Developers.                             *
  *                                                                            *
+ * See the COPYING file at                                                    *
+ * https://github.com/KomodoPlatform/komodo/blob/master/COPYING               *
  * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
- * the top-level directory of this distribution for the individual copyright  *
- * holder information and the developer policies on copyright and licensing.  *
+ * https://github.com/KomodoPlatform/komodo/tree/master/LEGAL                 *
+ * for the individual copyright holder information and the developer policies *
+ * on copyright and licensing.                                                *
  *                                                                            *
  * Unless otherwise agreed in a custom licensing agreement, no part of the    *
  * SuperNET software, including this file may be copied, modified, propagated *

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -350,7 +350,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     memset(ctinv,0,sizeof(ctinv));
     memset(zflags,0,sizeof(zflags));
     if ( pindexLast != 0 )
-        height = (int32_t)pindexLast->GetHeight() + 1;
+        height = (int32_t)pindexLast->nHeight + 1;
     if ( /*ASSETCHAINS_ADAPTIVEPOW > 0 &&*/ pindexFirst != 0 && pblock != 0 && height >= (int32_t)(sizeof(ct)/sizeof(*ct)) )
     {
         tipdiff = (pblock->nTime - pindexFirst->nTime);
@@ -380,7 +380,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     for (i = 0; pindexFirst && i < params.nPowAveragingWindow; i++)
     {
         bnTmp.SetCompact(pindexFirst->nBits);
-        if ( /*ASSETCHAINS_ADAPTIVEPOW > 0*/ && pblock != 0 )
+        if ( /*ASSETCHAINS_ADAPTIVEPOW > 0 &&*/ pblock != 0 )
         {
             blocktime = pindexFirst->nTime;
             diff = (pblock->nTime - blocktime);
@@ -407,7 +407,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
     bool fNegative,fOverflow; int32_t past,zawyflag = 0; arith_uint256 easy,origtarget,bnAvg {bnTot / params.nPowAveragingWindow};
     nbits = CalculateNextWorkRequired(bnAvg, pindexLast->GetMedianTimePast(), pindexFirst->GetMedianTimePast(), params);
-    if ( /*ASSETCHAINS_ADAPTIVEPOW > 0*/ )
+    if ( 1 /*ASSETCHAINS_ADAPTIVEPOW > 0*/ )
     {
         bnTarget = arith_uint256().SetCompact(nbits);
         if ( height > (int32_t)(sizeof(ct)/sizeof(*ct)) && pblock != 0 && tipdiff > 0 )

--- a/src/pow.h
+++ b/src/pow.h
@@ -17,8 +17,6 @@ class arith_uint256;
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
-unsigned int lwmaGetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
-unsigned int lwmaCalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&);
 unsigned int CalculateNextWorkRequired(arith_uint256 bnAvg,
                                        int64_t nLastBlockTime, int64_t nFirstBlockTime,
                                        const Consensus::Params&);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -990,6 +990,8 @@ static const CRPCCommand commands[] =
   //  --------------------- ------------------------  -----------------------  ----------
     { "mining",             "getnetworkhashps",       &getnetworkhashps,       {"nblocks","height"} },
     { "mining",             "getmininginfo",          &getmininginfo,          {} },
+    { "mining",             "genminingCSV",           &genminingCSV,           {} },
+    
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  {"txid","dummy","fee_delta"} },
     { "mining",             "getblocktemplate",       &getblocktemplate,       {"template_request"} },
     { "mining",             "submitblock",            &submitblock,            {"hexdata","dummy"} },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -129,7 +129,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
         CBlockIndex* pindexPrev = chainActive.Tip();
-        UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
+        UpdateTime(pblock, Params().GetConsensus(), pindexPrev);
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++pblock->nNonce;
             --nMaxTries;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -137,8 +137,8 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++pblock->nNonce;
             --nMaxTries;
-            pindexPrev = chainActive.Tip(); // in case there is a new block on the network
-            UpdateTime(pblock, Params().GetConsensus(), pindexPrev); // in case nBits changed due to huge delay without block
+            //pindexPrev = chainActive.Tip(); // in case there is a new block on the network
+            //UpdateTime(pblock, Params().GetConsensus(), pindexPrev); // in case nBits changed due to huge delay without block
         }
         if (nMaxTries == 0) {
             break;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -41,7 +41,7 @@ unsigned int ParseConfirmTarget(const UniValue& value)
 
 /**
  * Return average network hashes per second based on the last 'lookup' blocks,
- * or from the last difficulty change if 'lookup' is nonpositive.
+ * or over the difficulty averaging window if 'lookup' is nonpositive.
  * If 'height' is nonnegative, compute the estimate at the time when a given block was found.
  */
 UniValue GetNetworkHashPS(int lookup, int height) {
@@ -53,10 +53,14 @@ UniValue GetNetworkHashPS(int lookup, int height) {
     if (pb == nullptr || !pb->nHeight)
         return 0;
 
-    // If lookup is -1, then use blocks since last difficulty change.
+    // If lookup is -1, then use difficulty averaging window.
     if (lookup <= 0)
-        lookup = pb->nHeight % Params().GetConsensus().DifficultyAdjustmentInterval() + 1;
+        lookup = pb->nHeight % Params().GetConsensus().nPowAveragingWindow;
 
+    // If lookup is still negative, then use blocks since genesis.
+    if (lookup <= 0)
+        lookup = pb->nHeight;
+    
     // If lookup is larger than chain, then set it to chain length.
     if (lookup > pb->nHeight)
         lookup = pb->nHeight;
@@ -87,10 +91,10 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
         throw std::runtime_error(
             "getnetworkhashps ( nblocks height )\n"
             "\nReturns the estimated network hashes per second based on the last n blocks.\n"
-            "Pass in [blocks] to override # of blocks, -1 specifies since last difficulty change.\n"
+            "Pass in [blocks] to override # of blocks, -1 specifies over difficulty averaging window.\n"
             "Pass in [height] to estimate the network speed at the time when a certain block was found.\n"
             "\nArguments:\n"
-            "1. nblocks     (numeric, optional, default=120) The number of blocks, or -1 for blocks since last difficulty change.\n"
+            "1. nblocks     (numeric, optional, default=120) The number of blocks, or -1 for blocks over difficulty averaging window.\n"
             "2. height      (numeric, optional, default=-1) To estimate at the time of the given height.\n"
             "\nResult:\n"
             "x             (numeric) Hashes per second estimated\n"

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -195,7 +195,6 @@ CBlockIndex *komodo_chainactive(int32_t height);
 arith_uint256 zawy_ctB(arith_uint256 bnTarget,uint32_t solvetime);
 
 UniValue genminingCSV(const JSONRPCRequest& request)
-    (const UniValue& params, bool fHelp, const CPubKey& mypk)
 {
     int32_t i,z,height; uint32_t solvetime,prevtime=0; FILE *fp; char str[65],str2[65],fname[256]; uint256 hash; arith_uint256 bnTarget; CBlockIndex *pindex; bool fNegative,fOverflow; UniValue result(UniValue::VOBJ);
     if (request.fHelp || request.params.size() != 0)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -123,10 +123,8 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
     while (nHeight < nHeightEnd)
     {
         std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript));
-        if (!pblocktemplate.get())  {
-            LogPrintf("Couldn't create new block");
+        if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
-            }
         CBlock *pblock = &pblocktemplate->block;
         {
             LOCK(cs_main);
@@ -137,8 +135,6 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
             ++pblock->nNonce;
             --nMaxTries;
-            //pindexPrev = chainActive.Tip(); // in case there is a new block on the network
-            //UpdateTime(pblock, Params().GetConsensus(), pindexPrev); // in case nBits changed due to huge delay without block
         }
         if (nMaxTries == 0) {
             break;
@@ -147,10 +143,8 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             continue;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))   {
-            LogPrintf("ProcessNewBlock, block not accepted");
+        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
-            }
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -197,7 +197,7 @@ arith_uint256 zawy_ctB(arith_uint256 bnTarget,uint32_t solvetime);
 UniValue genminingCSV(const JSONRPCRequest& request)
 {
     int32_t i,z,height; uint32_t solvetime,prevtime=0; FILE *fp; char str[65],str2[65],fname[256]; uint256 hash; arith_uint256 bnTarget; CBlockIndex *pindex; bool fNegative,fOverflow; UniValue result(UniValue::VOBJ);
-    if (request.fHelp || request.params.size() != 0)
+    if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(
             "genminingCSV\n");
     LOCK(cs_main);
@@ -206,7 +206,7 @@ UniValue genminingCSV(const JSONRPCRequest& request)
     {
         fprintf(fp,"height,nTime,nBits,bnTarget,bnTargetB,diff,solvetime\n");
         height = chainActive.Height(); //komodo_nextheight();
-        for (i=0; i<height; i++)
+        for (i=request.params[0].get_int(); i<height; i++)
         {
             if ( (pindex= komodo_chainactive(i)) != 0 )
             {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -191,6 +191,54 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
     return generateBlocks(coinbaseScript, nGenerate, nMaxTries, false);
 }
 
+CBlockIndex *komodo_chainactive(int32_t height);
+arith_uint256 zawy_ctB(arith_uint256 bnTarget,uint32_t solvetime);
+
+UniValue genminingCSV(const JSONRPCRequest& request)
+    (const UniValue& params, bool fHelp, const CPubKey& mypk)
+{
+    int32_t i,z,height; uint32_t solvetime,prevtime=0; FILE *fp; char str[65],str2[65],fname[256]; uint256 hash; arith_uint256 bnTarget; CBlockIndex *pindex; bool fNegative,fOverflow; UniValue result(UniValue::VOBJ);
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+            "genminingCSV\n");
+    LOCK(cs_main);
+    sprintf(fname,"%s_mining.csv","CHIPS");
+    if ( (fp= fopen(fname,"wb")) != 0 )
+    {
+        fprintf(fp,"height,nTime,nBits,bnTarget,bnTargetB,diff,solvetime\n");
+        height = komodo_nextheight();
+        for (i=0; i<height; i++)
+        {
+            if ( (pindex= komodo_chainactive(i)) != 0 )
+            {
+                bnTarget.SetCompact(pindex->nBits,&fNegative,&fOverflow);
+                solvetime = (prevtime==0) ? 0 : (int32_t)(pindex->nTime - prevtime);
+                for (z=0; z<16; z++)
+                    sprintf(&str[z<<1],"%02x",((uint8_t *)&bnTarget)[31-z]);
+                str[32] = 0;
+                //hash = pindex->GetBlockHash();
+                memset(&hash,0,sizeof(hash));
+                if ( i >= 64 && (pindex->nBits & 3) != 0 )
+                    hash = ArithToUint256(zawy_ctB(bnTarget,solvetime));
+                for (z=0; z<16; z++)
+                    sprintf(&str2[z<<1],"%02x",((uint8_t *)&hash)[31-z]);
+                str2[32] = 0; fprintf(fp,"%d,%u,%08x,%s,%s,%.1f,%d\n",i,pindex->nTime,pindex->nBits,str,str2,GetDifficulty(pindex),solvetime);
+                prevtime = pindex->nTime;
+            }
+        }
+        fclose(fp);
+        result.push_back(Pair("result", "success"));
+        result.push_back(Pair("created", fname));
+    }
+    else
+    {
+        result.push_back(Pair("result", "success"));
+        result.push_back(Pair("error", "couldnt create mining.csv"));
+        result.push_back(Pair("filename", fname));
+    }
+    return(result);
+}
+
 UniValue getmininginfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -990,8 +990,7 @@ static const CRPCCommand commands[] =
   //  --------------------- ------------------------  -----------------------  ----------
     { "mining",             "getnetworkhashps",       &getnetworkhashps,       {"nblocks","height"} },
     { "mining",             "getmininginfo",          &getmininginfo,          {} },
-    { "mining",             "genminingCSV",           &genminingCSV,           {} },
-    
+    { "mining",             "genminingCSV",           &genminingCSV,           {"beginHeight"} },
     { "mining",             "prioritisetransaction",  &prioritisetransaction,  {"txid","dummy","fee_delta"} },
     { "mining",             "getblocktemplate",       &getblocktemplate,       {"template_request"} },
     { "mining",             "submitblock",            &submitblock,            {"hexdata","dummy"} },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -134,7 +134,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             ++pblock->nNonce;
             --nMaxTries;
             pindexPrev = chainActive.Tip(); // in case there is a new block on the network
-            UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev); // in case nBits changed due to huge delay without block
+            UpdateTime(pblock, Params().GetConsensus(), pindexPrev); // in case nBits changed due to huge delay without block
         }
         if (nMaxTries == 0) {
             break;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -197,16 +197,16 @@ arith_uint256 zawy_ctB(arith_uint256 bnTarget,uint32_t solvetime);
 UniValue genminingCSV(const JSONRPCRequest& request)
 {
     int32_t i,z,height; uint32_t solvetime,prevtime=0; FILE *fp; char str[65],str2[65],fname[256]; uint256 hash; arith_uint256 bnTarget; CBlockIndex *pindex; bool fNegative,fOverflow; UniValue result(UniValue::VOBJ);
-    if (request.fHelp || request.params.size() != 1)
+    if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(
-            "genminingCSV\n");
+            "genminingCSV beginHeight\n");
     LOCK(cs_main);
     sprintf(fname,"%s_mining.csv","CHIPS");
     if ( (fp= fopen(fname,"wb")) != 0 )
     {
         fprintf(fp,"height,nTime,nBits,bnTarget,bnTargetB,diff,solvetime\n");
         height = chainActive.Height(); //komodo_nextheight();
-        for (i=request.params[0].get_int(); i<height; i++)
+        for (i=(!request.params[0].isNull() ? request.params[0].get_int() : height - 2000); i<height; i++)
         {
             if ( (pindex= komodo_chainactive(i)) != 0 )
             {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -205,7 +205,7 @@ UniValue genminingCSV(const JSONRPCRequest& request)
     if ( (fp= fopen(fname,"wb")) != 0 )
     {
         fprintf(fp,"height,nTime,nBits,bnTarget,bnTargetB,diff,solvetime\n");
-        height = komodo_nextheight();
+        height = chainActive.Height(); //komodo_nextheight();
         for (i=0; i<height; i++)
         {
             if ( (pindex= komodo_chainactive(i)) != 0 )

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -154,7 +154,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    ProcessNewBlock(chainparams, 10000000, shared_pblock, true, nullptr); // 10000000 to simulate a height after apow HF height
 
     CBlock result = block;
     return result;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3355,7 +3355,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
                     {
                         pindex->nStatus |= BLOCK_FAILED_MASK;
                         fprintf(stderr,"known block.%d found invalid prevblock\n",(int32_t)pindex->nHeight);
-                        return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+                        return state.DoS(100, error("%s: prev block invalid 1", __func__), REJECT_INVALID, "bad-prevblk");
                     }
                 }
                 if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
@@ -3378,7 +3378,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
             return state.DoS(10, error("%s: prev block not found", __func__), 0, "prev-blk-not-found");
         pindexPrev = (*mi).second;
         if (pindexPrev->nStatus & BLOCK_FAILED_MASK)
-            return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+            return state.DoS(100, error("%s: prev block invalid 2", __func__), REJECT_INVALID, "bad-prevblk");
         if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
             return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
@@ -3392,7 +3392,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
                         setDirtyBlockIndex.insert(invalid_walk);
                         invalid_walk = invalid_walk->pprev;
                     }
-                    return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+                    return state.DoS(100, error("%s: prev block invalid 3", __func__), REJECT_INVALID, "bad-prevblk");
                 }
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3018,7 +3018,8 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
         if (block.GetBlockTime() > GetAdjustedTime() + 4)
         {
             LogPrintf("CheckBlockHeader block from future %d error",block.GetBlockTime() - GetAdjustedTime());
-            return false;
+            return state.DoS(50, false, REJECT_INVALID, "block-from-future", false, "CheckBlockHeader block from future");
+            // return false;
         }
     }
     

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3017,9 +3017,8 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
     {
         if (block.GetBlockTime() > GetAdjustedTime() + 4)
         {
-            LogPrintf("CheckBlockHeader block from future %d error",block.GetBlockTime() - GetAdjustedTime());
+            // LogPrintf("CheckBlockHeader block from future %d error",block.GetBlockTime() - GetAdjustedTime());
             return state.DoS(50, false, REJECT_INVALID, "block-from-future", false, "CheckBlockHeader block from future");
-            // return false;
         }
     }
     

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3013,7 +3013,7 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
     if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
-    if ( chainActive.Height() > consensusParams.nAdaptativePoWActivationThreshold )
+    if ( chainActive.Height() > consensusParams.nAdaptivePoWActivationThreshold )
     {
         if (block.GetBlockTime() > GetAdjustedTime() + 4)
         {
@@ -3195,7 +3195,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
         }
     }
 
-    if ( pindexPrev->nHeight + 1 <= consensusParams.nAdaptativePoWActivationThreshold || nHeight < 30 )
+    if ( pindexPrev->nHeight + 1 <= consensusParams.nAdaptivePoWActivationThreshold || nHeight < 30 )
     {
         // Check timestamp against prev
         if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3171,7 +3171,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();
-    LogPrintf(" === ContextualCheckBlockHeader: block.nBits = %d GetNextWorkRequired = %d\n", block.nBits, GetNextWorkRequired(pindexPrev, &block, consensusParams));
+    // LogPrintf(" [apow test] === ContextualCheckBlockHeader: block.nBits = %d GetNextWorkRequired = %d\n", block.nBits, GetNextWorkRequired(pindexPrev, &block, consensusParams));
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
@@ -3576,7 +3576,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, FormatStateMessage(state));
     if (!CheckBlock(block, pindexPrev->nHeight+1, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
-    if (!ContextualCheckBlock(block, pindexPrev->nHeight+1, state, chainparams.GetConsensus(), pindexPrev))
+    if (!ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindexPrev))
         return error("%s: Consensus::ContextualCheckBlock: %s", __func__, FormatStateMessage(state));
     if (!g_chainstate.ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1792,7 +1792,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     // is enforced in ContextualCheckBlockHeader(); we wouldn't want to
     // re-enforce that rule here (at least until we make it impossible for
     // GetAdjustedTime() to go backward).
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck))
+    if (!CheckBlock(block, pindex->nHeight, state, chainparams.GetConsensus(), !fJustCheck, !fJustCheck))
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
 
     // verify that the view's current state corresponds to the previous block
@@ -3007,15 +3007,13 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
     return true;
 }
 
-static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
+static bool CheckBlockHeader(const CBlockHeader& block, int32_t height, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true)
 {
     // Check proof of work matches claimed amount
     if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
         return state.DoS(50, false, REJECT_INVALID, "high-hash", false, "proof of work failed");
 
-    /*
-    // TO DO: I need the blockheight here to check the following condition only for APOW:
-    if ( block.nHeight > consensusParams.nAdaptativePoWActivationThreshold )
+    if ( height > consensusParams.nAdaptativePoWActivationThreshold )
     {
         if (block.GetBlockTime() > GetAdjustedTime() + 4)
         {
@@ -3023,12 +3021,11 @@ static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state,
             return false;
         }
     }
-    */
     
     return true;
 }
 
-bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
+bool CheckBlock(const CBlock& block, int32_t height, CValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
 {
     // These are checks that are independent of context.
 
@@ -3037,7 +3034,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
+    if (!CheckBlockHeader(block, height, state, consensusParams, fCheckPOW))
         return false;
 
     // Check the merkle root.
@@ -3495,7 +3492,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     }
     if (fNewBlock) *fNewBlock = true;
 
-    if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
+    if (!CheckBlock(block, pindex->nHeight, state, chainparams.GetConsensus()) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
         if (state.IsInvalid() && !state.CorruptionPossible()) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
@@ -3540,7 +3537,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         CValidationState state;
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
-        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
+        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus()); // TODOPH
 
         LOCK(cs_main);
 
@@ -3577,9 +3574,9 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
     // NOTE: CheckBlockHeader is called by CheckBlock
     if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
         return error("%s: Consensus::ContextualCheckBlockHeader: %s", __func__, FormatStateMessage(state));
-    if (!CheckBlock(block, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
+    if (!CheckBlock(block, pindexPrev->nHeight+1, state, chainparams.GetConsensus(), fCheckPOW, fCheckMerkleRoot))
         return error("%s: Consensus::CheckBlock: %s", __func__, FormatStateMessage(state));
-    if (!ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindexPrev))
+    if (!ContextualCheckBlock(block, pindexPrev->nHeight+1, state, chainparams.GetConsensus(), pindexPrev))
         return error("%s: Consensus::ContextualCheckBlock: %s", __func__, FormatStateMessage(state));
     if (!g_chainstate.ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;
@@ -4000,7 +3997,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
             return error("VerifyDB(): *** ReadBlockFromDisk failed at %d, hash=%s", pindex->nHeight, pindex->GetBlockHash().ToString());
         // check level 1: verify block validity
-        if (nCheckLevel >= 1 && !CheckBlock(block, state, chainparams.GetConsensus()))
+        if (nCheckLevel >= 1 && !CheckBlock(block, pindex->nHeight, state, chainparams.GetConsensus()))
             return error("%s: *** found bad block at %d, hash=%s (%s)\n", __func__,
                          pindex->nHeight, pindex->GetBlockHash().ToString(), FormatStateMessage(state));
         // check level 2: verify undo validity


### PR DESCRIPTION
### Adaptive PoW (apow) is a Difficulty Adjustment Algorythm (DAA) that was created by jl777 and zawy12, there were several iterations. This PR ports apow version of 28 september 2019 into Chips.

Until now, Chips is using the original Bitcoin DAA (difficulty retarget after 2016 blocks) so after 2016 blocks, difficulty can decrease (or increase). Apow DAA allows to have difficulty retarget between 2 blocks then the coin network hashrate can change from ASIC hashrate to CPU hashrate without having chain stalling. With Bitcoin DAA, no CPU can find a block if ASIC's were mining during previous 2016 blocks windows. With apow DAA, a CPU could find a block after around 15 times the blocktime.

In addition to apow DAA, this PR contains a blockheight activated hard fork and adapations of some RPC calls used for mining.

**Sources:**
https://github.com/jl777/komodo/pull/1677/files
Searches of ASSETCHAINS_ADAPTIVEPOW in komodo code
**Edit:** I used the version/iteration of this commit: https://github.com/jl777/komodo/commit/e86e40a155145ff4b5eab6293f75731798f82324#diff-ba91592f703a9d0badf94e67144bc0aa
https://github.com/jl777/komodo/blob/e86e40a155145ff4b5eab6293f75731798f82324/src/pow.cpp
Commit of 8 August "Fix past windows, reduce exp() window from 12 to 6, for zawy20"

The HF proposed block is 6795000 (5th Augustus 2020 at around 8:30 PM).
Edit: postponed to 23rd August, block 6874120.

### How to mine Chips with CPU?
0) Check your system clock, your clock must be correct (you can use ntp)
1) Install Chips
2) Sync Chips blockchain
3) Create a file mine.sh with the following content (change bWQKUzuWKJYCpDAv93xNuceANgL3aQ559k to your address):
```bash
#!/bin/bash

DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
cd ${DIR}

date
echo started in ${DIR}

while true; do
        chips-cli generatetoaddress 100 'bWQKUzuWKJYCpDAv93xNuceANgL3aQ559k' 1000000
done
exec bash
```
4) Launch mine.sh
5) Wait to see some blocks found:
[
  "0000005fc29af24789558f4cc24fd876f675600a6651976dec7ab6c3ea1c531e",
  "00000066efaf9496ce26ae28459be6449cea68c36a41ddedca12b990e79d967b",
  "00000061ca9c9588553977ed76c6d6165770a9887971fc0139d2d8a69bb52f38"
]

Other RPC Calls exist for mining, setgenerate was removed when Chips was created but the generate RPC call was still used on regtest. Stratum mining works using usual RPC calls (getblocktemplate, submitblock and getinfo).

### Tests performed:
- Tests of the HF on a local network of 3 Chips nodes: after the HF height, the 3 nodes rejected blocks from Chips network using Bitcoin DAA and disconnected from whole Chips network except the 3 local nodes. The IP of the 3 nodes were not banned from Chips network.
- Test of CPU mining after the HF: the first block took less than 2 minutes for each test of the HF. CPU mining continued during one hour, all 2 nodes were still aligned.
- Test of Stratum mining with GPU & ASIC: Stratum mining works fine (tested using yiimp)
- Test of ASIC attacks: after several minutes of CPU mining (CPU level difficulty), if an ASIC begins to mine Chips through stratum, blocks are found quickly then difficulty is increased and the blocktime tends to be 10 seconds after a dozen of blocks. ASIC needs jobs with high difficulty so low difficulty error was displayed on the ASIC. See graphs here below to see the results when ASIC begins to mine and when ASIC stops to mine.
![image](https://user-images.githubusercontent.com/31578435/88123475-3ec32f00-cbcb-11ea-8a96-642c8333da66.png)
Thank you to SHossain who helped me to test this with his ASIC.
- Test of GPU attacks: stratum difficulty was configured to 8192 for ASIC mining but I tested with 0.1 and 1 with a GPU, the GPU was able to mine more blocks than ASIC when it begins to mine but after a dozen of blocks, ASIC and GPU were mining the same number of blocks per second (and blocktime tends to 10 seconds)
- Test of mining with several nodes: if 2 or 3 nodes are mining after the HF, there is no chainsplit and blocks found by one node are accepted by other nodes
- Test of the "no block in the future" rule: the clock of any miner can't be more than 4 seconds in the future or its blocks found will be rejected by other nodes. I tested it with one miner on a server with a bad clock and other chips nodes (after the HF) rejected properly these blocks too far in the future.
- Test of genminingCSV while mining with CPU: genminingCSV should not be used very often. Developers and explorers may be interested. If a node is mining and genminingCSV RPC call is triggered, the CPU mining will be slowed down by huge ressources used by genminingCSV.

Each test was reproduced several times. Other tests were performed but not related to DAA and HF.

### Illustrations of ASIC tests:

**ASIC Test 1:**

![image](https://user-images.githubusercontent.com/31578435/88123520-54d0ef80-cbcb-11ea-9f72-33e57eddf5d1.png)
Since apow DAA is targeting that the average blocktime/solvetime to be around 10 seconds with a moving average of 17, jl777 adviced to look at the average blocktime:
![image](https://user-images.githubusercontent.com/31578435/88123601-85b12480-cbcb-11ea-85e6-bb5df20d1c15.png)
For this test, the HF was at block 664444.
The average blocktime is below 25 seconds.
I think that the huge blocktime for block 6644504 is because genminingCSV was walled on the cpu mining node leading to less ressouces for CPU mining.

**ASIC Test 2:**

![image](https://user-images.githubusercontent.com/31578435/88123868-14be3c80-cbcc-11ea-8a74-73252f918359.png)
Average blocktime:
![image](https://user-images.githubusercontent.com/31578435/88123895-21429500-cbcc-11ea-8a13-bccbf05050b0.png)

Details of test setup and scripts used are available at:
https://gist.github.com/phm87/7a5388aa97e05f9ecf3b98d5b242e0ad

Test results, logs and comments of community contributors are available on Chips discord or on demand. 

A big thank you to jl777 who helped and coatched me a lot during the integration, I learnt a lot about coins internals. Thank you to everyone who helped and supported me: SHossain, NutellaLicka, metaphilibert, Chips community and Komodo community.