### PR TITLE
Resolve compilation failure when linking target 'qt/test/test_bitcoin-qt'

### DIFF
--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -50,7 +50,7 @@ endif
 
 nodist_qt_test_test_bitcoin_qt_SOURCES = $(TEST_QT_MOC_CPP)
 
-qt_test_test_bitcoin_qt_LDADD = $(LIBBITCOINQT) $(LIBBITCOIN_SERVER)
+qt_test_test_bitcoin_qt_LDADD = $(LIBBITCOINQT) $(LIBBITCOIN_SERVER) $(LIBCRYPTOCONDITIONS)
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_LDADD += $(LIBBITCOIN_WALLET)
 endif


### PR DESCRIPTION
Cryptoconditions library was not linked properly with the chips-qt testing suite.

This PR resolves the compilation failure that resulted.