### PR TITLE
Automatically set '-txindex=1', to avoid importing of NN addresses

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -129,7 +129,7 @@ static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
 /** Default for -permitbaremultisig */
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = false;
+static const bool DEFAULT_TXINDEX = true;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;


### PR DESCRIPTION
- Was causing wallet bloat
- Should investigate if splicing off 'komodo_importaddress' functionality from 'txindex' startup flag is worthwhile

I will need to look into things further to determine if *not importing* KMD NN addresses will adversely affect chips in context of dPoW.  If it does not, we could add a startup flag (i.e. `-importnnaddresses` or similar), where we can toggle (independently of `-txindex` flag) this behavior.