### PR TITLE
Add omitted bech32_hrp definition

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -165,6 +165,8 @@ public:
         base58Prefixes[EXT_PUBLIC_KEY] = {0x04, 0x88, 0xB2, 0x1E};
         base58Prefixes[EXT_SECRET_KEY] = {0x04, 0x88, 0xAD, 0xE4};
 
+        bech32_hrp = "bc";
+
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
         fDefaultConsistencyChecks = false;


### PR DESCRIPTION
- These values exist on non-mainnet params, but not on main chain.  As a result, segwit addresses fail to properly encode (i.e. `1qlfxchu46qpyndndld5fjdqa2udes00md5esvxe` rather than `bc1qlfxchu46qpyndndld5fjdqa2udes00mdrp729z`)