### PR TITLE
Fix non-local lambda expression compilation error

### DIFF
--- a/src/test-komodo/test_eval_notarisation.cpp
+++ b/src/test-komodo/test_eval_notarisation.cpp
@@ -57,7 +57,7 @@ public:
     }
 };
 
-static auto noop = [&](CMutableTransaction &mtx){};
+static auto noop = [](CMutableTransaction &mtx){};
 
 
 template<typename Modifier>


### PR DESCRIPTION
Prior to this commit, compilation fails with error:

```
test-komodo/test_eval_notarisation.cpp:60:21: error: non-local lambda expression cannot have a capture-default
   60 | static auto noop = [&](CMutableTransaction &mtx){};
```

After removing capture, compilation succeeds as expected.