### PR TITLE
Add rescan height parameter for importprivkey

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -112,6 +112,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "lockunspent", 0, "unlock" },
     { "lockunspent", 1, "transactions" },
     { "importprivkey", 2, "rescan" },
+    { "importprivkey", 3, "height" },
     { "importaddress", 2, "rescan" },
     { "importaddress", 3, "p2sh" },
     { "importpubkey", 2, "rescan" },


### PR DESCRIPTION
Allows us to call `importprivkey` with an optional 4th parameter:

`importprivkey <WIF> "" true <height>`

This helps a lot with notary wallet maintenance.  I added this code just now for my own use, so might as well PR.